### PR TITLE
Adjust regex & add error

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function trim(str) {
     str = str
         .replace(/^url\s?\(/, '')
         .replace(/\)$/, '')
+        .trim()
         .replace(/^("|\')/, '')
         .replace(/("|\')$/, '');
 
@@ -25,10 +26,13 @@ function trim(str) {
  */
 
 module.exports = function (str) {
-    var regex = /(url\s?\()?(\'|")(.*)(\'|")(\))?/gi;
+    var regex = /(?:url\s?\((?:.*)\))|(\'|")(?:.*)\1/gi;
     var ret = {};
 
-    ret.path = trim(str.match(regex).toString());
+    var found = str.match(regex);
+    if (!found) {throw new Error("Could not find a valid import path in string: "+str);}
+
+    ret.path = trim(found.toString());
     ret.condition = str.replace(/(^|\s)@import(\s|$)/gi, '').replace(regex, '').replace(' ', '');
     ret.rule = str;
 


### PR DESCRIPTION
Fixes #1. Adjust regex to accept url() paths with no quotes, reject paths with unmatched quotes, and trim spaces between parens and quotes. Also throws a descriptive error when it cannot find a valid path.
