### PR TITLE
Fix @import url() parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function trim(str) {
  */
 
 module.exports = function (str) {
-    var regex = /(?:url\s?\((?:.*)\))|(\'|")(?:.*)\1/gi;
+    var regex = /(?:url\s?\((?:[^)]+)\))|(\'|")(?:.*)\1/gi;
     var ret = {};
 
     if (!str.match(regex)) {

--- a/test.js
+++ b/test.js
@@ -5,8 +5,26 @@ var assert = require('assert');
 var parseImport = require('./');
 
 describe('parseImport()', function () {
-    it('should parse @import', function (cb) {
+    it('should parse bare string @import', function (cb) {
         var ret = parseImport('@import "test/foo.css" (min-width: 25em)');
+
+        assert.strictEqual(ret.path, 'test/foo.css');
+        assert.strictEqual(ret.condition, '(min-width: 25em)');
+
+        cb();
+    });
+
+    it('should parse url() quoted @import', function (cb) {
+        var ret = parseImport('@import url("test/foo.css") (min-width: 25em)');
+
+        assert.strictEqual(ret.path, 'test/foo.css');
+        assert.strictEqual(ret.condition, '(min-width: 25em)');
+
+        cb();
+    });
+
+    it('should parse url() non-quoted @import', function (cb) {
+        var ret = parseImport('@import url(test/foo.css) (min-width: 25em)');
 
         assert.strictEqual(ret.path, 'test/foo.css');
         assert.strictEqual(ret.condition, '(min-width: 25em)');


### PR DESCRIPTION
Now parse-import support `@import` for quoted & non quoted url \o/
This will allow us to ignore http:// imported url in rework-import.
